### PR TITLE
Revert "Fix devm_led_classdev_register call"

### DIFF
--- a/patches/hid-apple-mod.patch
+++ b/patches/hid-apple-mod.patch
@@ -13,14 +13,6 @@ index 1cb4199..3f30d04 100644
   */
 
  /*
- @@ -16,6 +17,7 @@
-
- #include <linux/device.h>
- #include <linux/hid.h>
-+#include <linux/leds.h>
- #include <linux/module.h>
- #include <linux/slab.h>
-
 @@ -30,6 +31,7 @@
  #define APPLE_INVERT_HWHEEL	0x0040
  #define APPLE_IGNORE_HIDINPUT	0x0080


### PR DESCRIPTION
Reverts mikeeq/mbp-fedora-kernel#10

https://cloud.drone.io/mikeeq/mbp-fedora-kernel/228/1/3
```
Applying: patch hid-apple-mod
1884 | Patch failed at 0096 patch hid-apple-mod
1885 | When you have resolved this problem, run "git am --continue".
1886 | If you prefer to skip this patch, run "git am --skip" instead.
1887 | To restore the original branch and stop patching, run "git am --abort".
1888 | error: Bad exit status from /var/tmp/rpm-tmp.6vEKLs (%prep)
1889 | extra tokens at the end of %else directive in line 656:  %else # released_kernel
1890 |  
1891 | extra tokens at the end of %endif directive in line 665:  %endif # released_kernel
```

