### PR TITLE
Fedora Linux v5.15.12, asahi brcmfmac changes

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -5,7 +5,7 @@ set -eu -o pipefail
 ## Update fedora docker image tag, because kernel build is using `uname -r` when defining package version variable
 RPMBUILD_PATH=/root/rpmbuild
 MBP_VERSION=mbp
-FEDORA_KERNEL_VERSION=5.15.5-200.fc35      # https://bodhi.fedoraproject.org/updates/?search=&packages=kernel&releases=F35
+FEDORA_KERNEL_VERSION=5.15.12-200.fc35      # https://bodhi.fedoraproject.org/updates/?search=&packages=kernel&releases=F35
 REPO_PWD=$(pwd)
 
 ### Debug commands

--- a/patch_driver.sh
+++ b/patch_driver.sh
@@ -8,7 +8,7 @@ set -eu -o pipefail
 APPLE_SMC_DRIVER_GIT_URL=https://github.com/jamlam/mbp-16.1-linux-wifi
 APPLE_SMC_REPO_NAME=mbp-16.1-linux-wifi
 APPLE_SMC_DRIVER_BRANCH_NAME=main
-APPLE_SMC_DRIVER_COMMIT_HASH=911efd340fd956e927f480d9b565c29f4f947d5b
+APPLE_SMC_DRIVER_COMMIT_HASH=edeb47a4363d3647ea543738b27f3962ff245197
 
 # TMP_DIR=~/temp_dir
 TMP_DIR=/tmp/temp_dir


### PR DESCRIPTION
Updates to the jamlam patches include asahilinux's changes to brcmfmac,
which have reading OTP data to select firmware working from linux. This
means that the firmware in /lib/firmware/brcm has a new naming scheme,
and we don't need to manually pick out which files to use. To do this
manually:

```sh
# in macos (or linux if you have a copy of the wifi folder):
git clone https://github.com/AsahiLinux/asahi-installer --depth=1
cd asahi-installer/src
python3 -m firmware.wifi /usr/share/firmware/wifi firmware.tar
# move "firmware.tar" to linux, and in linux run:
cd /lib/firmware
sudo tar xf /path/to/firmware.tar
```