### PR TITLE
Enable signing of rpms

### DIFF
--- a/.github/workflows/yum-repo.yml
+++ b/.github/workflows/yum-repo.yml
@@ -16,4 +16,4 @@ jobs:
         run: ./publish.sh
         env:
           HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
-          RPM_SIGNING_KEY: ${{ secrets.RPM_SIGING_KEY }}
+          RPM_SIGNING_KEY: ${{ secrets.RPM_SIGNING_KEY }}

--- a/.github/workflows/yum-repo.yml
+++ b/.github/workflows/yum-repo.yml
@@ -16,3 +16,4 @@ jobs:
         run: ./publish.sh
         env:
           HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
+          RPM_SIGNING_KEY: ${{ secrets.RPM_SIGING_KEY }}

--- a/build.sh
+++ b/build.sh
@@ -47,7 +47,7 @@ echo >&2 "===]> Info: Setting kernel name... ";
 sed -i "s/# define buildid.*/%define buildid .${MBP_VERSION}/" "${RPMBUILD_PATH}"/SPECS/kernel.spec
 
 ### Import rpm siging keys
-cat $RPM_SIGING_KEY > ./rpm_siging_key
+cat $RPM_SIGNING_KEY > ./rpm_signing_key
 sudo rpm --import ./rpm_signing_key
 
 ### Build non-debug rpms

--- a/build.sh
+++ b/build.sh
@@ -46,10 +46,14 @@ done < <(find "${REPO_PWD}"/patches -type f -name "*.patch" | sort)
 echo >&2 "===]> Info: Setting kernel name... ";
 sed -i "s/# define buildid.*/%define buildid .${MBP_VERSION}/" "${RPMBUILD_PATH}"/SPECS/kernel.spec
 
+### Import rpm siging keys
+cat $RPM_SIGING_KEY > ./rpm_siging_key
+sudo rpm --import ./rpm_signing_key
+
 ### Build non-debug rpms
 echo >&2 "===]> Info: Bulding kernel ... ";
 cd "${RPMBUILD_PATH}"/SPECS
-rpmbuild -bb --without debug --without debuginfo --without perf --without tools --target=x86_64 kernel.spec
+rpmbuild -bb --without debug --without debuginfo --without perf --without tools --target=x86_64 --sign kernel.spec
 rpmbuild_exitcode=$?
 
 ### Copy artifacts to shared volume


### PR DESCRIPTION
Make the CI sign the rpms after being built. A github secret called RPM_SIGNING_KEY is necessary for this to work. Run:
```
# Create gpg key pair. Leave the password blank, and make the user of this key RPM_SIGNING_KEY
gpg --gen-key
gpg --export -a 'Package Manager' > ./RPM_SIGNING_KEY
```
Then copy the contents of `./RPM_SIGNING_KEY` into the secret.