### PR TITLE
Add dependencies for kernel-devel RPM to update_kernel_mbp script

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Github Actions kernel publish status - <https://fedora-mbp-repo.herokuapp.com/> 
 
 ## How to update mbp-fedora-kernel
 
-Starting from Fedora 37 `mbp-fedora` release - `mbp-fedora-kernel` should be automatically updated using builtin package manager - DNF, so simply run `dnf update`, and it should automatically fetch all required updates.
+Starting from Fedora 37 `mbp-fedora` release - `mbp-fedora-kernel` should be automatically updated using builtin package manager - DNF, so simply run `dnf update --refresh`, and it should automatically fetch all required updates.
 
 If the DNF fail, or you're updating your older `mbp-fedora`, you can still use previously used method with `update_kernel_mbp` described below.
 

--- a/update_kernel_mbp.sh
+++ b/update_kernel_mbp.sh
@@ -91,10 +91,13 @@ if [[ -n "${KERNEL_VERSION:-}" ]] || [ "${INSTALL_LATEST:-false}" = true ] || [ 
     curl -LO "https://github.com/mikeeq/mbp-fedora-kernel/releases/download/v${MBP_KERNEL_TAG}/${i}"
   done
 
+  echo >&2 "===]> Info: Installing dependencies...";
+  dnf install -y gcc openssl-devel flex elfutils bison elfutils-libelf-devel
+
   echo >&2 "===]> Info: Installing kernel version: ${MBP_KERNEL_TAG}";
   rpm --force -i ./*.rpm
 else
-  echo >&2 "===]> Info: Installing latest kernel from repo";
+  echo >&2 "===]> Info: Installing latest kernel from repo...";
   dnf update -y kernel kernel-core kernel-modules mbp-fedora-t2-config mbp-fedora-t2-repo
 fi
 

--- a/yum-repo/specs/mbp-fedora-t2-config.spec
+++ b/yum-repo/specs/mbp-fedora-t2-config.spec
@@ -22,8 +22,6 @@ cp %{_sourcedir}/rmmod_tb.sh %{_builddir}/
 tar -xf %{_sourcedir}/t2-better-audio-%{KEKRBY_AUDIO_CONFIGS}.tar.gz
 
 %build
-# TODO: add update script?
-
 echo -e 'hid-apple\nbcm5974\nsnd-seq\napple_bce' > apple_bce.conf
 echo -e 'add_drivers+=" hid_apple snd-seq apple_bce "\nforce_drivers+=" hid_apple snd-seq apple_bce "' > apple_bce_install.conf
 # https://github.com/t2linux/wiki/pull/343/files

--- a/yum-repo/specs/mbp-fedora-t2-config.spec
+++ b/yum-repo/specs/mbp-fedora-t2-config.spec
@@ -22,6 +22,8 @@ cp %{_sourcedir}/rmmod_tb.sh %{_builddir}/
 tar -xf %{_sourcedir}/t2-better-audio-%{KEKRBY_AUDIO_CONFIGS}.tar.gz
 
 %build
+# TODO: add update script?
+
 echo -e 'hid-apple\nbcm5974\nsnd-seq\napple_bce' > apple_bce.conf
 echo -e 'add_drivers+=" hid_apple snd-seq apple_bce "\nforce_drivers+=" hid_apple snd-seq apple_bce "' > apple_bce_install.conf
 # https://github.com/t2linux/wiki/pull/343/files


### PR DESCRIPTION
TODO:

```
===]> Info: Installing kernel version: 6.0.7-f37
warning: ./kernel-6.0.7-300.mbp.fc37.x86_64.rpm: Header V4 RSA/SHA256 Signature, key ID 5c0f98a4: NOKEY
error: Failed dependencies:
	bison is needed by kernel-devel-6.0.7-300.mbp.fc37.x86_64
	elfutils-libelf-devel is needed by kernel-devel-6.0.7-300.mbp.fc37.x86_64
	flex is needed by kernel-devel-6.0.7-300.mbp.fc37.x86_64
	gcc is needed by kernel-devel-6.0.7-300.mbp.fc37.x86_64
	openssl-devel is needed by kernel-devel-6.0.7-300.mbp.fc37.x86_64
[root@localhost-live ~]# dnf install -y gcc openssl-devel flex elfutils bison elfutils-libelf-devel

```