### PR TITLE
fix: typo in curl command

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ If the DNF fail, or you're updating your older `mbp-fedora`, you can still use p
 ```bash
 ### First run or if you want to update your copy of update_kernel_mbp script
 sudo -i
-curl -L https://raw.githubusercontent.com/mikeeq/mbp-fedora-kernel/v6.0-f38/update_kernel_mbp.sh -o /usr/bin/update_kernel_mbp
+curl -L https://raw.githubusercontent.com/mikeeq/mbp-fedora-kernel/v6.3-f38/update_kernel_mbp.sh -o /usr/bin/update_kernel_mbp
 chmod +x /usr/bin/update_kernel_mbp
 update_kernel_mbp
 


### PR DESCRIPTION
The correct branch is v6.3, this fixes typo there.